### PR TITLE
memperbaiki bug dalam mengambil data dari http://thesportsdb.com/api/v1/json/1/search_all_teams.php?l=

### DIFF
--- a/app/src/main/java/com/dicoding/kotlinacademy/teams/TeamsFragment.kt
+++ b/app/src/main/java/com/dicoding/kotlinacademy/teams/TeamsFragment.kt
@@ -57,7 +57,7 @@ class TeamsFragment : Fragment(), AnkoComponent<Context>, TeamsView {
         presenter = TeamsPresenter(this, request, gson)
         spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View, position: Int, id: Long) {
-                leagueName = spinner.selectedItem.toString()
+                leagueName = spinner.selectedItem.toString().replace(" ", "%20")
                 presenter.getTeamList(leagueName)
             }
 


### PR DESCRIPTION
Android Studio cannot read space, this caused an error when get some data from the API, so i change the code to  leagueName = spinner.selectedItem.toString().replace(" ", "%20")

Ada bug di dalam mengambil data dari Endpoint http://thesportsdb.com/api/v1/json/1/search_all_teams.php?l=
Sehingga mau tidak mau harus menggunakan Uri Parse di dalam ObjectAPI, yang dimana Uri Parse akan menciptakan konflik saat proses testing. Apabila tidak ingin ada konflik dalam proses testing maka dalam fungsi yang kita buat di ObjectAPI harus langsung menggunakan cara
 fun getTeams(league: String?): String {
        return BuildConfig.BASE_URL + "api/v1/json/${BuildConfig.TSDB_API_KEY}" + "/search_all_teams.php?l=" + league
    }
Akan tetapi jika menggunakan fungsi ini tanda spasi tidak akan bisa terbaca dan diconvert oleh Android Studio menjadi %20, sedangkan apabila ingin mendapatkan data dari endpoint tanda spasi itu harus dirubah menjadi %20
Example: 
![screen shot 2018-10-11 at 12 51 58 pm](https://user-images.githubusercontent.com/18338574/46900250-55eace00-cec9-11e8-9a51-e259edd2e0de.png)
akan terbaca Argentinian%20Primera%20League jika menggunakan Uri Parse
Sedangkan akan terbaca Argentinian Primera League apabila menggunakan return BuilConfig secara langsung

Maka dari itu saya memperbaiki salah code agar mengubah spasi " " menjadi "%20" agar bisa terbaca oleh Android studio yang dimana agar kita bisa mendaatkan data dari endpoint tsb
Brikut code yang akan saya rubah:
// leagueName adalah variabel String
 leagueName = spinner.selectedItem.toString().replace(" ", "%20")
                presenter.getTeamList(leagueName)